### PR TITLE
fix(client): syntax error

### DIFF
--- a/src/client/client.lua
+++ b/src/client/client.lua
@@ -15,5 +15,5 @@ AddStateBagChangeHandler('isOnDuty', nil, function(bagName, key, value, _reserve
 
             return lib.notify({ title = locale("duty_off"), type = 'infrom', position = 'top' })
         end
-    end, GetEntityModel(cache.ped)
+    end, GetEntityModel(cache.ped))
 end)


### PR DESCRIPTION
It was not even possible to run the resource in the first place.