### PR TITLE
refactor: consistency and cleanup

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,13 +1,33 @@
-fx_version "adamant"
-game "gta5"
-use_fxv2_oal "yes"
-lua54 "yes"
+fx_version 'cerulean'
+game 'gta5'
+use_fxv2_oal 'yes'
+lua54 'yes'
 
-name "lm-staffduty"
-author "Arootsy"
-version "1.0.0"
+name 'lm-staffduty'
+author 'Arootsy'
+version '1.0.0'
 
-client_scripts { "src/client/*.lua" }
-server_scripts { "src/server/*.lua", "@oxmysql/lib/MySQL.lua" }
-shared_scripts { "@es_extended/imports.lua", "@ox_lib/init.lua" }
-file { "shared/*.lua", "locales/*.json" }	
+dependencies {
+	'ox_lib'
+}
+
+shared_scripts {
+    '@ox_lib/init.lua'
+}
+
+client_scripts {
+    'src/client/*.lua'
+}
+
+server_scripts {
+    'src/server/*.lua'
+}
+
+files {
+    'locales/*.json',
+    'shared/*.lua'
+}
+
+ox_libs {
+    'locale'
+}

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -3,9 +3,8 @@ local Config = {}
 Config.Command = { 'staffdienst', 'staffduty', 'sd' } -- Config.Command = 'staffduty' IS ALSO POSSIBLE
 
 Config.AllowedGroups = {
-    ['user'] = false,
-    ['admin'] = true,
-    ['superadmin'] = true
+    'group.admin',
+    'group.superadmin',
 }
 
 Config.Outfits = {

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,11 +1,11 @@
 local Config = {}
 
-Config.Command = { "staffdienst", "staffduty", "sd" } -- ALSO Config.Command = "staffduty" IS POSSIBLE
+Config.Command = { 'staffdienst', 'staffduty', 'sd' } -- Config.Command = 'staffduty' IS ALSO POSSIBLE
 
 Config.AllowedGroups = {
-    ["user"] = false,
-    ["admin"] = true,
-    ["superadmin"] = true
+    ['user'] = false,
+    ['admin'] = true,
+    ['superadmin'] = true
 }
 
 Config.Outfits = {

--- a/src/client/client.lua
+++ b/src/client/client.lua
@@ -1,19 +1,12 @@
--- // [STARTUP] \\ --
-lib.locale()
-
--- // [STATEBAG] \\ --
-
-AddStateBagChangeHandler('isOnDuty', nil, function(bagName, key, value, _reserved, replicated)
+AddStateBagChangeHandler('isOnDuty', nil, function(_, _, value)
     lib.callback('illenium-appearance:server:getAppearance', false, function(skin)
         if value then
             TriggerServerEvent('txsv:checkIfAdmin')
-
-            return lib.notify({ title = locale("duty_on"), type = 'infrom', position = 'top' })
         else
             TriggerEvent('skinchanger:loadSkin', skin)
-            TriggerEvent('txcl:setAdmin', false, false, locale("no_access"))
-
-            return lib.notify({ title = locale("duty_off"), type = 'infrom', position = 'top' })
+            TriggerEvent('txcl:setAdmin', false, false, locale('no_access'))
         end
-    end, GetEntityModel(cache.ped)
+
+        lib.notify({ title = value and locale('duty_on') or locale('duty_off'), type = 'info' })
+    end, GetEntityModel(cache.ped))
 end)

--- a/src/server/server.lua
+++ b/src/server/server.lua
@@ -1,12 +1,7 @@
--- // [STARTUP] \\ --
-
-lib.locale()
-local Config = require('shared.config')
-
--- // [COMMANDS] \\ --
+local Config = require 'shared.config'
 
 lib.addCommand(Config.Command, {
-    help = locale("command_help"),
+    help = locale('command_help'),
     restricted = function()
         local restricted = {}
 
@@ -18,21 +13,20 @@ lib.addCommand(Config.Command, {
 
         return restricted
     end,
-}, function(source, args, raw)
-    Player(source).state.isOnDuty = not Player(source).state.isOnDuty
+}, function(source)
+    local state = Player(source).state
+    state.isOnDuty = not state.isOnDuty
 
-    if Player(source).state.isOnDuty then
+    if state.isOnDuty then
         TriggerClientEvent('illenium-appearance:client:loadJobOutfit', source, { outfitData = Config.Outfits[GetEntityModel(GetPlayerPed(source))] })
     end
 end)
 
--- // [EVENTS] \\ --
-
 RegisterNetEvent('txsv:checkIfAdmin', function()
     local src = source
     Wait(100) -- Required for txAdmin Wait server side.
-    
+
     if not Player(src).state.isOnDuty then
-        TriggerClientEvent("txcl:setAdmin", src, false, false, locale("no_access"))
+        TriggerClientEvent('txcl:setAdmin', src, false, false, locale('no_access'))
     end
 end)

--- a/src/server/server.lua
+++ b/src/server/server.lua
@@ -2,17 +2,7 @@ local Config = require 'shared.config'
 
 lib.addCommand(Config.Command, {
     help = locale('command_help'),
-    restricted = function()
-        local restricted = {}
-
-        for group, allowed in pairs(Config.AllowedGroups) do
-            if allowed then
-                table.insert(restricted, 'group.' .. group)
-            end
-        end
-
-        return restricted
-    end,
+    restricted = Config.AllowedGroups,
 }, function(source)
     local state = Player(source).state
     state.isOnDuty = not state.isOnDuty


### PR DESCRIPTION
Made a couple improvements.
- Replaced outdated fx_version with cerulean.
- Fixed notify type and removed position so user setting gets used.
- Fixed consistent use of quote type. 
- Removed unused es_extended and oxmysql imports.
- Added ox_lib to dependencies.
- Used of ox_libs instead of lib.locale() function.